### PR TITLE
Server#start returns self for creating new instance with method chain

### DIFF
--- a/lib/glint/server.rb
+++ b/lib/glint/server.rb
@@ -27,6 +27,7 @@ module Glint
       end
 
       Util.wait_port(port)
+      self
     end
 
     def stop

--- a/spec/lib/glint/server_spec.rb
+++ b/spec/lib/glint/server_spec.rb
@@ -70,9 +70,9 @@ module Glint
           exec File.expand_path("../../../bin/server.rb", __FILE__), port.to_s
         end
       }
-      before { server.start }
 
       it {
+        expect(server.start).to equal(server)
         expect(server.child_pid).to be_true
       }
     end


### PR DESCRIPTION
I want to write like below:

```
server = Glint::Server.new do |port|
    ....
end.start
```
